### PR TITLE
Update example-blocking.html

### DIFF
--- a/web-worker/example-blocking.html
+++ b/web-worker/example-blocking.html
@@ -20,6 +20,6 @@
       <div class="slidecontainer">
          <input type="range" min="1" max="100" value="50" class="slider" id="myRange">
       </div>
-      <span id="answer"> </span>
+      <span id="answer"> If you can see this text, WebAssembly code is still running... </span>
    </body>
 </html>


### PR DESCRIPTION
Suggested change to make it more obvious for reader that web assembly code is running (and therefore the slider is unresponsive)