### PR TITLE
Use cmath, std::abs instead of C equivalents.

### DIFF
--- a/kitchen-sink/newtonraphson.cpp
+++ b/kitchen-sink/newtonraphson.cpp
@@ -1,6 +1,6 @@
 #include "newtonraphson.hpp"
 #include "algebra.cpp"
-#include <math.h>
+#include <cmath>
 
 // Define the constructor method of NewtonRaphson instances
 NewtonRaphson::NewtonRaphson(float tolerance_in) : tolerance(tolerance_in) {}
@@ -14,6 +14,6 @@ float NewtonRaphson::solve(float initial_guess) {
     delta_x = equation(x) / derivative(x);
     iterations.push_back({i++, x, equation(x), derivative(x), delta_x});
     x = x - delta_x;
-  } while (fabs(delta_x) >= tolerance);
+  } while (std::abs(delta_x) >= tolerance);
   return x;
 };

--- a/vega/README.md
+++ b/vega/README.md
@@ -54,7 +54,7 @@ record the value of relevant variables in each cycle, as follows:
 ```cpp
 #include "newtonraphson.hpp"
 #include "algebra.cpp"
-#include <math.h>
+#include <cmath>
 
 // Define the constructor method of NewtonRaphson instances
 NewtonRaphson::NewtonRaphson(float tolerance_in) : tolerance(tolerance_in) {}
@@ -68,7 +68,7 @@ float NewtonRaphson::solve(float initial_guess) {
     delta_x = equation(x) / derivative(x);
     iterations.push_back({i++, x, equation(x), derivative(x), delta_x});
     x = x - delta_x;
-  } while (fabs(delta_x) >= tolerance);
+  } while (std::abs(delta_x) >= tolerance);
   return x;
 };
 ```

--- a/vega/newtonraphson.cpp
+++ b/vega/newtonraphson.cpp
@@ -1,6 +1,6 @@
 #include "newtonraphson.hpp"
 #include "algebra.cpp"
-#include <math.h>
+#include <cmath>
 
 // Define the constructor method of NewtonRaphson instances
 NewtonRaphson::NewtonRaphson(float tolerance_in) : tolerance(tolerance_in) {}
@@ -14,6 +14,6 @@ float NewtonRaphson::solve(float initial_guess) {
     delta_x = equation(x) / derivative(x);
     iterations.push_back({i++, x, equation(x), derivative(x), delta_x});
     x = x - delta_x;
-  } while (fabs(delta_x) >= tolerance);
+  } while (std::abs(delta_x) >= tolerance);
   return x;
 };

--- a/web-worker/newtonraphson.cpp
+++ b/web-worker/newtonraphson.cpp
@@ -1,6 +1,6 @@
 #include "newtonraphson.hpp"
 #include "algebra.cpp"
-#include <math.h>
+#include <cmath>
 #include <unistd.h> // for sleep
 
 // Define the constructor method of NewtonRaphson instances
@@ -13,7 +13,7 @@ float NewtonRaphson::solve(float initial_guess) {
   do {
     delta_x = equation(x) / derivative(x);
     x = x - delta_x;
-  } while (fabs(delta_x) >= tolerance);
+  } while (std::abs(delta_x) >= tolerance);
 
   // Artificially make this code slow
   sleep(5);

--- a/webassembly/README.md
+++ b/webassembly/README.md
@@ -110,7 +110,7 @@ File ``newtonraphson.cpp`` contains the corresponding implementation:
 ```cpp
 #include "newtonraphson.hpp"
 #include "algebra.cpp"
-#include <math.h>
+#include <cmath>
 
 // Define the constructor method of NewtonRaphson instances
 NewtonRaphson::NewtonRaphson(float tolerance_in) : tolerance(tolerance_in) {}
@@ -122,7 +122,7 @@ float NewtonRaphson::solve(float initial_guess) {
   do {
     delta_x = equation(x) / derivative(x);
     x = x - delta_x;
-  } while (fabs(delta_x) >= tolerance);
+  } while (std::abs(delta_x) >= tolerance);
   return x;
 };
 ```

--- a/webassembly/newtonraphson.cpp
+++ b/webassembly/newtonraphson.cpp
@@ -1,6 +1,6 @@
 #include "newtonraphson.hpp"
 #include "algebra.cpp"
-#include <math.h>
+#include <cmath>
 
 // Define the constructor method of NewtonRaphson instances
 NewtonRaphson::NewtonRaphson(float tolerance_in) : tolerance(tolerance_in) {}
@@ -12,6 +12,6 @@ float NewtonRaphson::solve(float initial_guess) {
   do {
     delta_x = equation(x) / derivative(x);
     x = x - delta_x;
-  } while (fabs(delta_x) >= tolerance);
+  } while (std::abs(delta_x) >= tolerance);
   return x;
 };


### PR DESCRIPTION
Dear Stefan,

please consider this minor change: C++ folks may frown upon or be distracted by the usage of C's fabs, <math.h>, instead of C++' std::abs, <cmath>

Thanks, Jan.